### PR TITLE
Refactored Value::Ranges coalesce().

### DIFF
--- a/include/mesos/values.hpp
+++ b/include/mesos/values.hpp
@@ -57,6 +57,9 @@ namespace values {
 
 Try<Value> parse(const std::string& text);
 
+// Sorts the ranges according to ascending range.begin().
+void sort(Value::Ranges* ranges);
+
 } // namespace values {
 } // namespace internal {
 

--- a/include/mesos/values.hpp
+++ b/include/mesos/values.hpp
@@ -57,9 +57,6 @@ namespace values {
 
 Try<Value> parse(const std::string& text);
 
-// Sorts the ranges according to ascending range.begin().
-void sort(Value::Ranges* ranges);
-
 } // namespace values {
 } // namespace internal {
 

--- a/src/tests/resources_tests.cpp
+++ b/src/tests/resources_tests.cpp
@@ -502,7 +502,7 @@ TEST(ResourcesTest, RangesSubset)
   EXPECT_EQ(1, ports2.ranges().range_size());
   EXPECT_EQ(1, ports3.ranges().range_size());
   EXPECT_EQ(2, ports4.ranges().range_size());
-  EXPECT_EQ(2, ports5.ranges().range_size());
+  EXPECT_EQ(1, ports5.ranges().range_size());
 
   Resources r1;
   r1 += ports1;

--- a/src/tests/values_tests.cpp
+++ b/src/tests/values_tests.cpp
@@ -33,9 +33,13 @@ using namespace mesos::internal::values;
 using std::string;
 
 namespace mesos {
+  extern void coalesce(Value::Ranges* ranges);
+  extern void coalesce(Value::Ranges* ranges, const Value::Range& range);
+} // namespace mesos {
+
+namespace mesos {
 namespace internal {
 namespace tests {
-
 
 TEST(ValuesTest, ValidInput)
 {
@@ -100,6 +104,342 @@ TEST(ValuesTest, SetSubtraction)
   set3 -= set1;
 
   EXPECT_EQ(set3, parse("{sda4}").get().set());
+}
+
+
+// Test a simple range parse.
+TEST(ValuesTest, RangesParse)
+{
+  Value::Ranges ranges;
+
+  Value::Range* range = ranges.add_range();
+  range->set_begin(1);
+  range->set_end(10);
+
+  Value::Ranges parsed =
+    parse("[1-10]").get().ranges();
+
+  EXPECT_EQ(ranges, parsed);
+}
+
+
+// Unit test sorting given ranges.
+TEST(ValuesTest, RangesSort)
+{
+  // Explicitly construct [4-5, 1-2, 2-3, 6-7].
+  Value::Ranges ranges;
+  Value::Range* range = ranges.add_range();
+  range->set_begin(4);
+  range->set_end(5);
+  range = ranges.add_range();
+  range->set_begin(1);
+  range->set_end(2);
+  range = ranges.add_range();
+  range->set_begin(2);
+  range->set_end(3);
+  range = ranges.add_range();
+  range->set_begin(6);
+  range->set_end(7);
+
+  sort(&ranges);
+
+  // Should be [ 1-2, 2-3, 4-5, 6-7].
+  ASSERT_EQ(4, ranges.range_size());
+  EXPECT_EQ(1, ranges.range(0).begin());
+  EXPECT_EQ(2, ranges.range(1).begin());
+  EXPECT_EQ(4, ranges.range(2).begin());
+  EXPECT_EQ(6, ranges.range(3).begin());
+}
+
+
+// Unit test coalescing given ranges.
+TEST(ValuesTest, RangesCoalesce)
+{
+  // Multiple overlap with explicit coalesce.
+  // Explicitly construct [1-4, 3-5, 7-8, 8-10].
+  Value::Ranges ranges;
+  Value::Range* range = ranges.add_range();
+  range->set_begin(1);
+  range->set_end(4);
+  range = ranges.add_range();
+  range->set_begin(3);
+  range->set_end(5);
+  range = ranges.add_range();
+  range->set_begin(7);
+  range->set_end(8);
+  range = ranges.add_range();
+  range->set_begin(8);
+  range->set_end(10);
+
+  sort(&ranges);
+  mesos::coalesce(&ranges);
+
+  // Should be [1-5, 7-10].
+  ASSERT_EQ(2, ranges.range_size());
+  EXPECT_EQ(1, ranges.range(0).begin());
+  EXPECT_EQ(5, ranges.range(0).end());
+  EXPECT_EQ(7, ranges.range(1).begin());
+  EXPECT_EQ(10, ranges.range(1).end());
+}
+
+
+// Test coalescing given ranges via parse.
+// Note: As the == operator triggers coalesce as well, we should
+// check ranges_size() explicitly.
+TEST(ValuesTest, RangesCoalesceParse)
+{
+  // Test multiple ranges against explicitly constructed.
+  Value::Ranges ranges;
+
+  Value::Range* range = ranges.add_range();
+  range->set_begin(1);
+  range->set_end(10);
+  Value::Ranges parsed =
+    parse("[4-6, 6-8, 5-9, 3-4, 2-5, 4-6, 1-1, 10-10, 4-6]").get().ranges();
+
+  EXPECT_EQ(ranges, parsed);
+  EXPECT_EQ(1, parsed.range_size());
+
+  // Simple overlap.
+  parsed = parse("[4-6, 6-8]").get().ranges();
+  Value::Ranges expected = parse("[4-8]").get().ranges();
+
+  EXPECT_EQ(parsed, expected);
+  EXPECT_EQ(1, parsed.range_size());
+
+  // Simple overlap unordered.
+  parsed = parse("[6-8, 4-6]").get().ranges();
+  expected = parse("[4-8]").get().ranges();
+
+  EXPECT_EQ(parsed, expected);
+  EXPECT_EQ(1, parsed.range_size());
+
+  // Subsumed range.
+  parsed = parse("[1-10, 8-10]").get().ranges();
+  expected = parse("[1-10]").get().ranges();
+
+  EXPECT_EQ(parsed, expected);
+  EXPECT_EQ(1, parsed.range_size());
+
+  // Completely subsumed.
+  parsed = parse("[1-11, 8-10]").get().ranges();
+  expected = parse("[1-11]").get().ranges();
+
+  EXPECT_EQ(parsed, expected);
+  EXPECT_EQ(1, parsed.range_size());
+
+  // Multiple overlapping ranges.
+  parsed = parse("[1-4, 4-5, 7-8, 8-10]").get().ranges();
+  expected = parse("[1-5, 7-10]").get().ranges();
+
+  EXPECT_EQ(parsed, expected);
+  EXPECT_EQ(2, parsed.range_size());
+
+  // Multiple overlap mixed.
+  parsed = parse("[7-8, 1-4, [8-10], 4-5]").get().ranges();
+  expected = parse("[1-5, 7-10]").get().ranges();
+
+  EXPECT_EQ(parsed, expected);
+  EXPECT_EQ(2, parsed.range_size());
+
+  // Simple neighboring with overlap.
+  parsed = parse("[4-6, 7-8]").get().ranges();
+  expected = parse("[4-8]").get().ranges();
+
+  EXPECT_EQ(parsed, expected);
+  EXPECT_EQ(1, parsed.range_size());
+
+  // Single neighbouring.
+  parsed = parse("[4-6, 7-7]").get().ranges();
+  expected = parse("[4-7]").get().ranges();
+
+  EXPECT_EQ(parsed, expected);
+  EXPECT_EQ(1, parsed.range_size());
+
+  // Multiple ranges coalescing into a single one.
+  parsed = parse("[4-6, 7-7, 8-8, 9-9]").get().ranges();
+  expected = parse("[4-9]").get().ranges();
+
+  EXPECT_EQ(parsed, expected);
+  EXPECT_EQ(1, parsed.range_size());
+
+  // Multiple ranges coalescing into multiple ranges.
+  parsed = parse("[4-6, 7-7, 9-10, 9-11]").get().ranges();
+  expected = parse("[4-7, 9-11]").get().ranges();
+
+  EXPECT_EQ(parsed, expected);
+  EXPECT_EQ(2, parsed.range_size());
+
+  // Multiple duplicates.
+  parsed = parse("[6-8, 6-8, 4-6, 6-8]").get().ranges();
+  expected = parse("[4-8]").get().ranges();
+  EXPECT_EQ(parsed, expected);
+  EXPECT_EQ(1, parsed.range_size());
+}
+
+
+// Test adding a new range to an existing coalesced range.
+// Note: As the == operator triggers coalesce as well, we should
+// check ranges_size() explicitly.
+TEST(ValuesTest, AddRangeCoalesce)
+{
+  // Multiple overlap with explicit coalesce.
+  // Explicitly construct [1-4, 8-10].
+  Value::Ranges ranges;
+  Value::Range* range = ranges.add_range();
+  range->set_begin(1);
+  range->set_end(4);
+  range = ranges.add_range();
+  range->set_begin(8);
+  range->set_end(10);
+
+  // Range [4-8].
+  Value::Range range2;
+  range2.set_begin(4);
+  range2.set_end(8);
+
+  mesos::coalesce(&ranges, range2);
+
+  // Should be coalesced to [1-10].
+  ASSERT_EQ(1, ranges.range_size());
+  EXPECT_EQ(1, ranges.range(0).begin());
+  EXPECT_EQ(10, ranges.range(0).end());
+
+  // Multiple neighboring with explicit coalesce.
+  // Range [5-7].
+  range2.set_begin(5);
+  range2.set_end(7);
+
+  mesos::coalesce(&ranges, range2);
+
+  // Should be coalesced to [1-10].
+  ASSERT_EQ(1, ranges.range_size());
+  EXPECT_EQ(1, ranges.range(0).begin());
+  EXPECT_EQ(10, ranges.range(0).end());
+
+  // Completely subsumed.
+  // Range [5-7] (as before).
+  range2.set_begin(5);
+  range2.set_end(7);
+
+  mesos::coalesce(&ranges, range2);
+
+  // Should be coalesced to [1-10].
+  ASSERT_EQ(1, ranges.range_size());
+  EXPECT_EQ(1, ranges.range(0).begin());
+  EXPECT_EQ(10, ranges.range(0).end());
+
+  // None overlapping.
+  // Range [5-7] (as before).
+  range2.set_begin(20);
+  range2.set_end(21);
+
+  mesos::coalesce(&ranges, range2);
+
+  // Should be coalesced to [1-10, 20-21].
+  ASSERT_EQ(2, ranges.range_size());
+  EXPECT_EQ(1, ranges.range(0).begin());
+  EXPECT_EQ(10, ranges.range(0).end());
+  EXPECT_EQ(20, ranges.range(1).begin());
+  EXPECT_EQ(21, ranges.range(1).end());
+}
+
+// Test adding two ranges.
+TEST(ValuesTest, RangesAddition)
+{
+  // Overlaps on right.
+  Value::Ranges ranges1 = parse("[3-8]").get().ranges();
+  Value::Ranges ranges2 = parse("[4-10]").get().ranges();
+
+  EXPECT_EQ(parse("[3-10]").get().ranges(), ranges1 + ranges2);
+
+  // Overlapps on right.
+  ranges1 = parse("[3-8]").get().ranges();
+  ranges2 = parse("[1-4]").get().ranges();
+
+  EXPECT_EQ(parse("[1-8]").get().ranges(), ranges1 + ranges2);
+
+  // Completely subsumed.
+  ranges1 = parse("[2-3]").get().ranges();
+  ranges2 = parse("[1-4]").get().ranges();
+
+  EXPECT_EQ(parse("[1-4]").get().ranges(), ranges1 + ranges2);
+
+  // Neighbouring right.
+  ranges1 = parse("[2-3]").get().ranges();
+  ranges2 = parse("[4-6]").get().ranges();
+
+  EXPECT_EQ(parse("[2-6]").get().ranges(), ranges1 + ranges2);
+
+  // Neighbouring left.
+  ranges1 = parse("[3-5]").get().ranges();
+  ranges2 = parse("[1-2]").get().ranges();
+
+  EXPECT_EQ(parse("[1-5]").get().ranges(), ranges1 + ranges2);
+
+  // Fills gap.
+  ranges1 = parse("[3-5, 7-8]").get().ranges();
+  ranges2 = parse("[6-6]").get().ranges();
+
+  EXPECT_EQ(parse("[3-8]").get().ranges(), ranges1 + ranges2);
+
+  // Fills double gap.
+  ranges1 = parse("[1-4, 9-10, 20-22, 26-30]").get().ranges();
+  ranges2 = parse("[5-8, 23-25]").get().ranges();
+
+  EXPECT_EQ(parse("[1-10, 20-30]").get().ranges(), ranges1 + ranges2);
+}
+
+// Test subtracting two ranges.
+TEST(ValuesTest, RangesSubtraction)
+{
+  // Completely subsumes.
+  Value::Ranges ranges1 = parse("[3-8]").get().ranges();
+  Value::Ranges ranges2 = parse("[1-10]").get().ranges();
+
+  EXPECT_EQ(parse("[]").get().ranges(), ranges1 - ranges2);
+
+  // Subsummed on left.
+  ranges1 = parse("[3-8]").get().ranges();
+  ranges2 = parse("[3-5]").get().ranges();
+
+  EXPECT_EQ(parse("[6-8]").get().ranges(), ranges1 - ranges2);
+
+  // Subsummed on right.
+  ranges1 = parse("[3-8]").get().ranges();
+  ranges2 = parse("[5-8]").get().ranges();
+
+  EXPECT_EQ(parse("[3-4]").get().ranges(), ranges1 - ranges2);
+
+  // Subsummed in the middle.
+  ranges1 = parse("[3-8]").get().ranges();
+  ranges2 = parse("[5-6]").get().ranges();
+
+  EXPECT_EQ(parse("[3-4, 7-8]").get().ranges(), ranges1 - ranges2);
+
+  // Overlaps to the left.
+  ranges1 = parse("[3-8]").get().ranges();
+  ranges2 = parse("[1-3]").get().ranges();
+
+  EXPECT_EQ(parse("[4-8]").get().ranges(), ranges1 - ranges2);
+
+  // Overlaps to the right.
+  ranges1 = parse("[3-8]").get().ranges();
+  ranges2 = parse("[5-10]").get().ranges();
+
+  EXPECT_EQ(parse("[3-4]").get().ranges(), ranges1 - ranges2);
+
+  // Doesn't overlap right.
+  ranges1 = parse("[3-8]").get().ranges();
+  ranges2 = parse("[9-10]").get().ranges();
+
+  EXPECT_EQ(parse("[3-8]").get().ranges(), ranges1 - ranges2);
+
+  // Doesn't overlap left.
+  ranges1 = parse("[3-8]").get().ranges();
+  ranges2 = parse("[1-2]").get().ranges();
+
+  EXPECT_EQ(parse("[3-8]").get().ranges(), ranges1 - ranges2);
 }
 
 } // namespace tests {

--- a/src/tests/values_tests.cpp
+++ b/src/tests/values_tests.cpp
@@ -123,35 +123,6 @@ TEST(ValuesTest, RangesParse)
 }
 
 
-// Unit test sorting given ranges.
-TEST(ValuesTest, RangesSort)
-{
-  // Explicitly construct [4-5, 1-2, 2-3, 6-7].
-  Value::Ranges ranges;
-  Value::Range* range = ranges.add_range();
-  range->set_begin(4);
-  range->set_end(5);
-  range = ranges.add_range();
-  range->set_begin(1);
-  range->set_end(2);
-  range = ranges.add_range();
-  range->set_begin(2);
-  range->set_end(3);
-  range = ranges.add_range();
-  range->set_begin(6);
-  range->set_end(7);
-
-  sort(&ranges);
-
-  // Should be [ 1-2, 2-3, 4-5, 6-7].
-  ASSERT_EQ(4, ranges.range_size());
-  EXPECT_EQ(1, ranges.range(0).begin());
-  EXPECT_EQ(2, ranges.range(1).begin());
-  EXPECT_EQ(4, ranges.range(2).begin());
-  EXPECT_EQ(6, ranges.range(3).begin());
-}
-
-
 // Unit test coalescing given ranges.
 TEST(ValuesTest, RangesCoalesce)
 {
@@ -171,7 +142,6 @@ TEST(ValuesTest, RangesCoalesce)
   range->set_begin(8);
   range->set_end(10);
 
-  sort(&ranges);
   mesos::coalesce(&ranges);
 
   // Should be [1-5, 7-10].


### PR DESCRIPTION
The goal of this refactoring was to reuse the Ranges objects as much as possible, as prior there was substantial time spend in allocation/destruction (MESOS-3051).

Review: https://reviews.apache.org/r/38158
